### PR TITLE
HOTFIX - Resolved Build Crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.6f1] - 2025-04-26
+
+### Fixed
+- Resolved build crash on Unity `6000.1` caused by `ProjectileMath.cs` use of `Mono.Cecil` 
+
 ## [0.0.6] - 2025-04-24
 
 ### Added

--- a/Runtime/Scripts/Utilities/Physics/ProjectileMath.cs
+++ b/Runtime/Scripts/Utilities/Physics/ProjectileMath.cs
@@ -1,9 +1,5 @@
 // Based on https://github.com/IronWarrior/ProjectileShooting/blob/master/Assets/Scripts/ProjectileMath.cs
-using System;
-using System.Collections.Generic;
-using Mono.Cecil;
 using UnityEngine;
-using UnityEngine.Assertions;
 
 namespace Utilities.Physics
 {


### PR DESCRIPTION
## Issue
- #35 

## Description
This PR addresses a build crash that was occuring on `Unity 6.1 - WebGL` builds caused by the existence of the `Mono.Cecil` namespace on `ProjectileMath.cs`

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change

## Checklist
- [x] Branch was updated from `develop/`
    - [x] All conflicts have been resolved
- [x] `CHANGELOG.md` was updated
- [x] Changes do not break
