### PR TITLE
Fixes to ensure that html docs pages build

### DIFF
--- a/WebsiteDocs~/.vitepress/prebuild.js
+++ b/WebsiteDocs~/.vitepress/prebuild.js
@@ -18,14 +18,19 @@ const fixCsLinks = (content) => {
         return `[${text}](${absoluteUrl})`;
     });
 };
-// Function to replace links starting with 'Documentation~' to be relative to the root
+// Function to replace links starting with 'Documentation~' or 'WebGLTemplates~' to be relative to the root
 const fixDocLinks = (content) => {
-    return content.replace(/\[([^\]]+)\]\((Documentation(?:~|%7E)[^\)]+)\)/g, (match, text, docPath) => {
+    return content.replace(/\[([^\]]+)\]\((((?:.*\/)*(?:Documentation|WebGLTemplates)(?:~|%7E))[^\)]+)\)/g, (match, text, docPath, replacePart) => {
       // Replace 'Documentation~' with the correct URL for documentation links
-      const relativeUrl = `${docPath.replace('Documentation~', '').replace('Documentation%7E', '')}`; // Adjust URL
+      let relativeUrl = `${docPath.replace(replacePart,'')}`; // Adjust URL
+
+      if (replacePart.includes('WebGLTemplates'))
+        relativeUrl = relativeUrl.replace('README','WebGL');
+    
       return `[${text}](${relativeUrl})`;
     });
   };
+
 
 // Function to replace containing capital extensions (ex .PNG)
 const fixCapitalLinks = (content) => {

--- a/WebsiteDocs~/package.json
+++ b/WebsiteDocs~/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "process-docs": "shx rm -rf ./site && shx cp -r ../Documentation~ ./site && shx cp *.md ./site && shx cp ../README.md ./site/home.md && node .vitepress/prebuild.js",
+    "process-docs": "shx rm -rf ./site && shx cp ../WebGLTemplates~/README.md ../Documentation~/WebGL.md && shx cp -r ../Documentation~ ./site && shx cp *.md ./site && shx cp ../README.md ./site/home.md && node .vitepress/prebuild.js",
     "copy-assets": "shx mkdir -p ./site/public && shx cp -r ./site/Images ./site/public",
     "predocs:dev": "npm run process-docs",
     "docs:dev": "vitepress dev",


### PR DESCRIPTION
## Description
The addition of WebGLTemplates~/README.md introduced more directories that need to be processed by the auto documentation building process.

## Tech Notes
I've added some additional preprocess steps in the Vite build scripts that ensure WebGL documentation pages will be included into the general documentation.

## Type of Change
- [x ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change

## Checklist
- [x] Branch was updated from `main/`
    - [x ] All conflicts have been resolved
- [x] `CHANGELOG.md` was updated
- [x] Changes do not break
