### PR TITLE
#40 Resolved race conditions in `SFXManager.cs` & `MusicController.cs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.7-preview] - 2025-06-25
+
+### Added
+
+
+### Changed
+
+
+### Fixed
+- Resolved potential race condition with `SFXManager.cs` sample when attempting to call `PlaySound()` on the first frame
+- Resolved potential race condition with `MusicController.cs` sample when attempting to call `PlayMusic()` on the first frame
+
 ## [0.0.6] - 2025-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ projects & Game jams.
 > For versions **previous to Unity 6**, use the following git url instead
 > - Paste `https://github.com/abr-designs/jam-starter-package.git#unity/version-support/pre-6000` into the text box
 
-### `v0.0.6` - Apr 24, 2025
+### `v0.0.7-preview` - DATE
 ### Supports Unity 6000.0
 
 ## Samples

--- a/Samples~/Sounds/Music/Scripts/MusicController.cs
+++ b/Samples~/Sounds/Music/Scripts/MusicController.cs
@@ -47,6 +47,8 @@ namespace Audio.Music
         
         private Dictionary<MUSIC, MusicData> _musicDataDictionary;
         
+        public bool _isReady;
+        
         //Unity Functions
         //============================================================================================================//
 
@@ -84,12 +86,17 @@ namespace Audio.Music
                 var vfxData = musicDatas[i];
                 _musicDataDictionary.Add(vfxData.type, vfxData);
             }
+            
+            _isReady = true;
         }
 
         //============================================================================================================//
 
         internal void PlayMusic(MUSIC music)
         {
+            if (!_isReady)
+                return;
+            
             //Don't need to fade into music that is already playing
             if (music == _currentMusic)
                 return;

--- a/Samples~/Sounds/SoundFx/Scripts/SFXManager.cs
+++ b/Samples~/Sounds/SoundFx/Scripts/SFXManager.cs
@@ -49,6 +49,8 @@ namespace Audio
 
         private Dictionary<SFX, SfxData> _sfxDataDictionary;
         private Dictionary<SFX, int> _sfxAntiSpam;
+        
+        private bool _isReady;
 
         //Unity Functions
         //============================================================================================================//
@@ -88,12 +90,16 @@ namespace Audio
             //------------------------------------------------//
 
             _audioSources = new List<AudioSource>();
+            _isReady = true;
         }
 
         //============================================================================================================//
 
         internal void PlaySound(SFX sfx, float volume = 1f)
         {
+            if(!_isReady)
+                return;
+            
             var sfxData = GetSFXData(sfx);
 
             var hasAntiSpam = _sfxAntiSpam.TryGetValue(sfx, out var count);
@@ -116,6 +122,9 @@ namespace Audio
         //This is meant to be called via the VFXExtensions class
         internal void PlaySoundAtLocation(SFX vfx, Vector3 worldPosition)
         {
+            if(!_isReady)
+                return;
+                        
             var sfxData = GetSFXData(vfx);
 
             var audioSource = TryGet3DAudioSource();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.abrds.jam-starter",
   "displayName": "Jam Starter Kit",
-  "version": "0.0.6",
+  "version": "0.0.7-preview",
   "unity": "6000.0",
   "description": "A collection of scripts & samples to help kick start Game Jam projects. Includes some custom packages",
   "keywords": [


### PR DESCRIPTION
## Issue
- #40 

## Description
This is a simple PR that implements an `isReady` bool into the `SFXManager.cs` & `MusicController.cs` that prevents early calls to the managers before the sound libraries have loaded.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change

## Checklist
- [x] Branch was updated from `develop/`
    - [x] All conflicts have been resolved
- [x] `CHANGELOG.md` was updated
- [x] Changes do not break
