### PR TITLE
Feature/#37 singletons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Singleton.cs` as a Singleton behaviour where the instance is publicly visible
 
 ### Changed
+- Set `SFXManager.cs`, `MusicController.cs` & `VFXManager.cs` to each utilize the `HiddenSingleton.cs` as a base class to maintain standard use
+  - Added static functions in each of these managers that be called from their relative extension classes to help enforce the `HiddenSingleton` structure
+- Updated `MusicController._isReady` to be `private` instead of `public`
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.7-preview] - 2025-06-25
+
+### Added
+
+
+### Changed
+
+
+### Fixed
+- Resolved potential race condition with `SFXManager.cs` sample when attempting to call `PlaySound()` on the first frame
+- Resolved potential race condition with `MusicController.cs` sample when attempting to call `PlayMusic()` on the first frame
+
 ## [0.0.6] - 2025-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.0.7-preview] - 2025-06-25
 
 ### Added
-
+- Added `Singleton.cs` as a Singleton behaviour where the instance is publicly visible
 
 ### Changed
 

--- a/Documentation~/Utilities/utilities-singletons.md
+++ b/Documentation~/Utilities/utilities-singletons.md
@@ -1,0 +1,60 @@
+﻿# Singletons
+The [Singleton pattern](https://refactoring.guru/design-patterns/singleton) solves two problems at the same time, violating the Single Responsibility Principle:
+1. Ensure that a class has just a single instance.
+2. Provide a global access point to that instance.
+
+Our implementation comes in two flavours:
+
+### `Singleton<T>`
+> [!CAUTION]
+> Be aware that if your implementation of `Singleton<T>` overrides `Awake()` you will have issues!
+
+This implementation is the most traditional, where the instance is generated & is publicly retrievable.
+- [`[DefaultExecutionOrder(-10000)]`](https://docs.unity3d.com/2022.3/Documentation/ScriptReference/DefaultExecutionOrder.html) ensures that this is executing with a higher priority
+
+```csharp
+[DefaultExecutionOrder(-10000)]
+public class Singleton<T> : MonoBehaviour where T : Object
+{
+    public static T Instance 
+    { 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get; 
+        private set; 
+    }
+    private void Awake()
+    {
+        if (Instance != null)
+        {
+            Debug.LogError($"Attempted to create Multiple instances of {typeof(T).Name}");
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this as T;
+    }
+}
+```
+
+### `HiddenSingleton<T>`
+This is my preferred implementation of a Singleton. This allows the behaviour to remain intact, but reduces outside access as much as possible.
+
+This is most useful when you just want to call a classes static function, but it still requires a scene instance to be
+present to maintain inspector references. _I do believe that a singleton pattern is not a great approach, but sometimes it
+is required._
+
+#### Example `SFXManager.cs`
+```csharp
+//This function is only visible to users!
+public static void PlaySound(SFX sfx, float volume = 1f)
+{
+    Assert.IsNotNull(Instance, $"Missing the {nameof(SFXManager)} in the Scene!!");
+    //Travels through this static function to call _PlaySound()
+    Instance._PlaySound(sfx, volume);
+}
+
+//private function only on the instance itself for data access
+private void _PlaySound(SFX sfx, float volume)
+{
+    //[...]    
+}
+```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ projects & Game jams.
 > For versions **previous to Unity 6**, use the following git url instead
 > - Paste `https://github.com/abr-designs/jam-starter-package.git#unity/version-support/pre-6000` into the text box
 
-### `v0.0.6` - Apr 24, 2025
+### `v0.0.7-preview` - DATE
 ### Supports Unity 6000.0
 
 ## Samples

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ projects & Game jams.
   - #### [Transform Tweens](Documentation~/Utilities/utilities-extensions-transform.md)
   - #### [Debugging - Draw.cs](Documentation~/Utilities/utilities-draw.md)
   - #### [Recycling](Documentation~/Utilities/utilities-recycling.md)
+  - #### [Singletons](Documentation~/Utilities/utilities-singletons.md)
 - ### [WebGL Templates](WebGLTemplates~/README.md)
 
 ---

--- a/Runtime/Scripts/Utilities/Singleton.cs
+++ b/Runtime/Scripts/Utilities/Singleton.cs
@@ -1,0 +1,32 @@
+﻿using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace Utilities
+{
+    /// <summary>
+    /// Used for session singletons that are to remain hidden(Dont' destroy object on Load)
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    [DefaultExecutionOrder(-10000)]
+    public class Singleton<T> : MonoBehaviour where T : Object
+    {
+        public static T Instance 
+        { 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get; 
+            private set; 
+        }
+
+        private void Awake()
+        {
+            if (Instance != null)
+            {
+                Debug.LogError($"Attempted to create Multiple instances of {typeof(T).Name}");
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this as T;
+        }
+    }
+}

--- a/Runtime/Scripts/Utilities/Singleton.cs.meta
+++ b/Runtime/Scripts/Utilities/Singleton.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a62d0ed3f6bf4d2898ee9c686e1ca30e
+timeCreated: 1750943884

--- a/Samples~/Sounds/Music/Scripts/MUSICExtensions.cs
+++ b/Samples~/Sounds/Music/Scripts/MUSICExtensions.cs
@@ -6,12 +6,7 @@ namespace Audio.Music
     {
         public static void PlayMusic(this MUSIC music)
         {
-            var musicController = MusicController;
-
-            Assert.IsNotNull(musicController, $"Missing the {nameof(MusicController)} in the Scene!!");
-            musicController.PlayMusic(music);
+            MusicController.PlayMusic(music);
         }
-
-        private static MusicController MusicController => MusicController.Instance;
     }
 }

--- a/Samples~/Sounds/Music/Scripts/MusicController.cs
+++ b/Samples~/Sounds/Music/Scripts/MusicController.cs
@@ -47,6 +47,8 @@ namespace Audio.Music
         
         private Dictionary<MUSIC, MusicData> _musicDataDictionary;
         
+        public bool _isReady;
+        
         //Unity Functions
         //============================================================================================================//
 
@@ -84,12 +86,17 @@ namespace Audio.Music
                 var vfxData = musicDatas[i];
                 _musicDataDictionary.Add(vfxData.type, vfxData);
             }
+            
+            _isReady = true;
         }
 
         //============================================================================================================//
 
         internal void PlayMusic(MUSIC music)
         {
+            if (!_isReady)
+                return;
+            
             //Don't need to fade into music that is already playing
             if (music == _currentMusic)
                 return;

--- a/Samples~/Sounds/Music/Scripts/MusicController.cs
+++ b/Samples~/Sounds/Music/Scripts/MusicController.cs
@@ -6,10 +6,11 @@ using Sounds;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.Audio;
+using Utilities;
 
 namespace Audio.Music
 {
-    public class MusicController : MonoBehaviour, ISetVolume
+    public class MusicController : HiddenSingleton<MusicController>, ISetVolume
     {
         //------------------------------------------------//
         
@@ -24,8 +25,6 @@ namespace Audio.Music
         }
 
         //------------------------------------------------//
-
-        internal static MusicController Instance;
 
         [SerializeField]
         private AudioMixer musicAudioMixer;
@@ -47,26 +46,16 @@ namespace Audio.Music
         
         private Dictionary<MUSIC, MusicData> _musicDataDictionary;
         
-        public bool _isReady;
+        private bool _isReady;
         
         //Unity Functions
         //============================================================================================================//
 
-        private void Awake()
-        {
-            if (Instance != null)
-            {
-                Destroy(gameObject);
-                return;
-            }
-
-            Instance = this;
-            Assert.IsNotNull(musicAudioMixer);
-        }
-
         // Start is called before the first frame update
         private void Start()
         {
+            Assert.IsNotNull(musicAudioMixer);
+            
             InitMusicLibrary();
 
             if (startMusic == MUSIC.NONE)
@@ -91,8 +80,12 @@ namespace Audio.Music
         }
 
         //============================================================================================================//
-
-        internal void PlayMusic(MUSIC music)
+        public static void PlayMusic(MUSIC music)
+        {
+            Assert.IsNotNull(Instance, $"Missing the {nameof(MusicController)} in the Scene!!");
+            Instance._PlayMusic(music);
+        }
+        private void _PlayMusic(MUSIC music)
         {
             if (!_isReady)
                 return;

--- a/Samples~/Sounds/SoundFx/Scripts/SFXExtensions.cs
+++ b/Samples~/Sounds/SoundFx/Scripts/SFXExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using UnityEngine.Assertions;
 
 namespace Audio.SoundFX
 {
@@ -7,20 +6,12 @@ namespace Audio.SoundFX
     {
         public static void PlaySoundAtLocation(this SFX sfx, Vector3 worldPosition)
         {
-            var sfxManager = SfxManager;
-            
-            Assert.IsNotNull(sfxManager, $"Missing the {nameof(SfxManager)} in the Scene!!");
-            sfxManager.PlaySoundAtLocation(sfx, worldPosition);
+            SFXManager.PlaySoundAtLocation(sfx, worldPosition);
         }
         
         public static void PlaySound(this SFX sfx, float volume = 1f)
         {
-            var sfxManager = SfxManager;
-            
-            Assert.IsNotNull(sfxManager, $"Missing the {nameof(SfxManager)} in the Scene!!");
-            sfxManager.PlaySound(sfx, volume);
+            SFXManager.PlaySound(sfx, volume);
         }
-
-        private static SFXManager SfxManager => SFXManager.Instance;
     }
 }

--- a/Samples~/Sounds/SoundFx/Scripts/SFXManager.cs
+++ b/Samples~/Sounds/SoundFx/Scripts/SFXManager.cs
@@ -49,6 +49,8 @@ namespace Audio
 
         private Dictionary<SFX, SfxData> _sfxDataDictionary;
         private Dictionary<SFX, int> _sfxAntiSpam;
+        
+        private bool _isReady;
 
         //Unity Functions
         //============================================================================================================//
@@ -88,12 +90,16 @@ namespace Audio
             //------------------------------------------------//
 
             _audioSources = new List<AudioSource>();
+            _isReady = true;
         }
 
         //============================================================================================================//
 
         internal void PlaySound(SFX sfx, float volume = 1f)
         {
+            if(!_isReady)
+                return;
+            
             var sfxData = GetSFXData(sfx);
 
             var hasAntiSpam = _sfxAntiSpam.TryGetValue(sfx, out var count);
@@ -116,6 +122,9 @@ namespace Audio
         //This is meant to be called via the VFXExtensions class
         internal void PlaySoundAtLocation(SFX vfx, Vector3 worldPosition)
         {
+            if(!_isReady)
+                return;
+                        
             var sfxData = GetSFXData(vfx);
 
             var audioSource = TryGet3DAudioSource();

--- a/Samples~/Sounds/SoundFx/Scripts/SFXManager.cs
+++ b/Samples~/Sounds/SoundFx/Scripts/SFXManager.cs
@@ -6,12 +6,15 @@ using Sounds;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.Audio;
+using Utilities;
 using Random = UnityEngine.Random;
 
 namespace Audio
 {
-    public class SFXManager : MonoBehaviour, ISetVolume
+    public class SFXManager : HiddenSingleton<SFXManager>, ISetVolume
     {
+        internal static SFXManager instance => Instance;
+        
         //============================================================================================================//
         [Serializable]
         private class SfxData
@@ -43,7 +46,6 @@ namespace Audio
         [SerializeField]
         private AudioSource sfxSourcePrefab;
         private List<AudioSource> _audioSources;
-        internal static SFXManager Instance;
 
         [SerializeField] private SfxData[] sfxDatas;
 
@@ -55,22 +57,12 @@ namespace Audio
         //Unity Functions
         //============================================================================================================//
 
-        private void Awake()
-        {
-            if (Instance != null)
-            {
-                Destroy(gameObject);
-                return;
-            }
-
-            Instance = this;
-            Assert.IsNotNull(sfxAudioMixer);
-            
-        }
-
         // Start is called before the first frame update
         private void Start()
         {
+            Assert.IsNotNull(sfxAudioMixer);
+
+            
             InitVfxLibrary();
 
             _sfxAntiSpam = new Dictionary<SFX, int>();
@@ -94,8 +86,12 @@ namespace Audio
         }
 
         //============================================================================================================//
-
-        internal void PlaySound(SFX sfx, float volume = 1f)
+        public static void PlaySound(SFX sfx, float volume = 1f)
+        {
+            Assert.IsNotNull(Instance, $"Missing the {nameof(SFXManager)} in the Scene!!");
+            Instance._PlaySound(sfx, volume);
+        }
+        private void _PlaySound(SFX sfx, float volume)
         {
             if(!_isReady)
                 return;
@@ -119,8 +115,13 @@ namespace Audio
             //FIXME This should just use a loop, and not a coroutine
             StartCoroutine(DequeueSFXCoroutine(sfx, audioClip.length));
         }
+        public static void PlaySoundAtLocation(SFX vfx, Vector3 worldPosition)
+        {
+            Assert.IsNotNull(Instance, $"Missing the {nameof(SFXManager)} in the Scene!!");
+            Instance._PlaySoundAtLocation(vfx, worldPosition);
+        }
         //This is meant to be called via the VFXExtensions class
-        internal void PlaySoundAtLocation(SFX vfx, Vector3 worldPosition)
+        private void _PlaySoundAtLocation(SFX vfx, Vector3 worldPosition)
         {
             if(!_isReady)
                 return;

--- a/Samples~/VisualFX/Scripts/VFXExtensions.cs
+++ b/Samples~/VisualFX/Scripts/VFXExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using UnityEngine.Assertions;
 
 namespace VisualFX
 {
@@ -7,12 +6,7 @@ namespace VisualFX
     {
         public static GameObject PlayAtLocation(this VFX vfx, Vector3 worldPosition, float scale = 1f, bool keepAlive = false)
         {
-            var vfxManager = VFXManager;
-            
-            Assert.IsNotNull(vfxManager, $"Missing the {nameof(VFXManager)} in the Scene!!");
-            return vfxManager.PlayAtLocation(vfx, worldPosition, scale, keepAlive);
+            return VFXManager.PlayAtLocation(vfx, worldPosition, scale, keepAlive);
         }
-
-        private static VFXManager VFXManager => VFXManager.Instance;
     }
 }

--- a/Samples~/VisualFX/Scripts/VFXManager.cs
+++ b/Samples~/VisualFX/Scripts/VFXManager.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Assertions;
+using Utilities;
 
 namespace VisualFX
 {
-    internal class VFXManager : MonoBehaviour
+    internal class VFXManager : HiddenSingleton<VFXManager>
     {
         //============================================================================================================//
         [Serializable]
@@ -22,8 +23,6 @@ namespace VisualFX
 
         //============================================================================================================//
 
-        internal static VFXManager Instance;
-
         [SerializeField]
         private VfxData[] vfxDatas;
 
@@ -31,17 +30,6 @@ namespace VisualFX
         
         //Unity Functions
         //============================================================================================================//
-
-        private void Awake()
-        {
-            if (Instance != null)
-            {
-                Destroy(gameObject);
-                return;
-            }
-            
-            Instance = this;
-        }
 
         // Start is called before the first frame update
         private void Start()
@@ -64,8 +52,14 @@ namespace VisualFX
         
         //============================================================================================================//
 
+        public static GameObject PlayAtLocation(VFX vfx, Vector3 worldPosition, float scale = 1f, bool keepAlive = false)
+        {
+            Assert.IsNotNull(Instance, $"Missing the {nameof(VFXManager)} in the Scene!!");
+            
+            return Instance._PlayAtLocation(vfx, worldPosition, scale, keepAlive);
+        }
         //This is meant to be called via the VFXExtensions class
-        internal GameObject PlayAtLocation(VFX vfx, Vector3 worldPosition, float scale = 1f, bool keepAlive = false)
+        private GameObject _PlayAtLocation(VFX vfx, Vector3 worldPosition, float scale, bool keepAlive)
         {
             var vfxData = GetVFXData(vfx);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.abrds.jam-starter",
   "displayName": "Jam Starter Kit",
-  "version": "0.0.6",
+  "version": "0.0.7-preview",
   "unity": "6000.0",
   "description": "A collection of scripts & samples to help kick start Game Jam projects. Includes some custom packages",
   "keywords": [


### PR DESCRIPTION
## Issue
- #37

## Description
This PR adds a new `Singleton<T>` class that can be inherited from, that allows a standardized way of initializing a Singleton, while allowing its instance to be publicly retrievable.

## Tech Notes
These changes also meant an opportunity to update the existing Samples that implemented their own singleton behaviours to now implement the standardized versions.

One problem with this is that ideally the instance is totally hidden, and the only way of accessing them is via the extension classes, however this would only be possible by including an assembly definition, which would no longer make this approachable.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [x] Refactor
- [ ] Breaking Change

## Checklist
- [x] Branch was updated from `develop/`
    - [x] All conflicts have been resolved
- [x] `CHANGELOG.md` was updated
- [x] Changes do not break
