### PR TITLE
Resolved `TweenTo` divide by 0 crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Set `SFXManager.cs`, `MusicController.cs` & `VFXManager.cs` to each utilize the `HiddenSingleton.cs` as a base class to maintain standard use
   - Added static functions in each of these managers that be called from their relative extension classes to help enforce the `HiddenSingleton` structure
 - Updated `MusicController._isReady` to be `private` instead of `public`
+- Added `null` catch for `TweenController.cs`
+- Added `Debug.LogError()` to `TweenController.InstantTween()` to advise avoiding using a `0s` tween time
 
 
 ### Fixed
 - Resolved potential race condition with `SFXManager.cs` sample when attempting to call `PlaySound()` on the first frame
 - Resolved potential race condition with `MusicController.cs` sample when attempting to call `PlayMusic()` on the first frame
+- Resolved divide by `0.0` in `TweenController.cs` that would cause a `NaN` error when setting the tween time to `0.0`
+  - This was resolved by auo-completing the tween in the event that the `time` value is `0f` by calling `InstantTween()`
 
 ## [0.0.6] - 2025-04-24
 

--- a/Runtime/Scripts/Utilities/Tweening/TweenController.cs
+++ b/Runtime/Scripts/Utilities/Tweening/TweenController.cs
@@ -131,6 +131,9 @@ namespace Utilities.Tweening
         
         internal TweenData SetData(bool worldSpace, TRANSFORM transformation, Transform targetTransform, float time, CURVE curve, Action onTweenComplete)
         {
+            if (targetTransform == null)
+                throw new ArgumentOutOfRangeException(nameof(targetTransform), $"{nameof(targetTransform)} should not be null!");
+            
             //Is the requested tween in Local or World space?
             _localTransformation = !worldSpace;
             Transformation = transformation;
@@ -171,6 +174,13 @@ namespace Utilities.Tweening
 
         internal bool Update(float deltaTime)
         {
+            //This circumstance should be avoided when possible, as it should just set the transformation
+            if (_totalTime <= 0f)
+            {
+                InstantTween();
+                return true;
+            }
+            
             //We want to countdown the time to the target
             _time = Math.Clamp(_time - deltaTime, 0f, _totalTime);
 
@@ -213,6 +223,45 @@ namespace Utilities.Tweening
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// In the event that the tween should be happening instantly, such as when the total tween time is zero, we do
+        /// so here. Returning True to indicate that the tween is completed.
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private void InstantTween()
+        {
+            Debug.LogError($"Attempting to apply {Transformation} to {TargetTransform.gameObject.name} with a time of {_totalTime:#0.0s}.\n" +
+                           "Tween's should only be used for movement over time, to instantly apply a tween, just set the transform.");
+            switch (Transformation)
+            {
+                case TRANSFORM.MOVE:
+                {
+                    if (_localTransformation)
+                        TargetTransform.localPosition = _targetPosition;
+                    else
+                        TargetTransform.position = _targetPosition;
+
+                    break;
+                }
+                case TRANSFORM.ROTATE:
+                {
+                    if (_localTransformation)
+                        TargetTransform.localRotation = _targetRotation;
+                    else
+                        TargetTransform.rotation = _targetRotation;
+                    break;
+                }
+                case TRANSFORM.SCALE:
+                {
+                    TargetTransform.localScale = _targetScale;
+                    break;
+                }
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
         
         private static float GetCurveT(CURVE curve, float t)


### PR DESCRIPTION
## Issue
- #46 

## Description
- Added `null` check for `targetTransform`
- Added check for `_totalTime` values `<= 0f`
- Added `TweenController.InstantTween()` to move the `targetTransform` to the target transformation if the total time is zero


## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change

## Checklist
- [x] Branch was updated from `develop/`
    - [x] All conflicts have been resolved
- [x] `CHANGELOG.md` was updated
- [x] Changes do not break
