### PR TITLE
#48 Improved `CollectionExtensions` Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Resolved potential race condition with `SFXManager.cs` sample when attempting to call `PlaySound()` on the first frame
 - Resolved potential race condition with `MusicController.cs` sample when attempting to call `PlayMusic()` on the first frame
+- Resolved `CollectionExtensions.PickRandomElement()` & `CollectionExtensions.Shuffle()` not catching null or empty list cases with clear exception
 
 ## [0.0.6] - 2025-04-24
 

--- a/Runtime/Scripts/Utilities/Extensions/CollectionExtensions.cs
+++ b/Runtime/Scripts/Utilities/Extensions/CollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 
 
@@ -10,6 +11,9 @@ namespace Utilities
         
         public static T PickRandomElement<T>(this T[] array)
         {
+            if (array == null || array.Length == 0)
+                throw new InvalidOperationException($"Passed collection is null or empty when calling {nameof(PickRandomElement)}!");
+            
             var randomIndex = Rand.Next(array.Length);
 
             return array[randomIndex];
@@ -17,6 +21,9 @@ namespace Utilities
 
         public static T PickRandomElement<T>(this IList<T> list)
         {
+            if (list == null || list.Count == 0)
+                throw new InvalidOperationException($"Passed collection is null or empty when calling {nameof(PickRandomElement)}!");
+            
             var randomIndex = Rand.Next(list.Count);
 
             return list[randomIndex];
@@ -25,6 +32,9 @@ namespace Utilities
         //Based on: https://stackoverflow.com/a/1262619
         public static void Shuffle<T>(this IList<T> list)
         {
+            if (list == null || list.Count == 0)
+                throw new InvalidOperationException($"Passed collection is null or empty when calling {nameof(Shuffle)}!");
+            
             int n = list.Count;
             while (n > 1)
             {
@@ -35,6 +45,9 @@ namespace Utilities
         }
         public static void Shuffle<T>(this T[] array)
         {
+            if (array == null || array.Length == 0)
+                throw new InvalidOperationException($"Passed collection is null or empty when calling {nameof(Shuffle)}!");
+            
             int n = array.Length;
             while (n > 1)
             {


### PR DESCRIPTION
## Issue
- #48 

## Description
> [!NOTE]
> Throwing an exception here is preferred to returning a `default` or `null` value, as the user may not be aware that they are passing an empty list, and should be ensuring that before calling the function.

An uncaught exception could occur when calling either of the following functions in `CollectionExtensions.cs`:
- `PickRandomElement()`
- `Shuffle()`

The exception would occur when passing a `null` or empty collection into the function throwing an `IndexOutOfRangeException` when it should have warned the user that the issue was caused by an empty collection.

The following exception is now thrown.
```cs
if (array == null || array.Length == 0)
    throw new InvalidOperationException($"Passed collection is null or empty when calling {nameof(PickRandomElement)}!");
```

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change

## Checklist
- [x] Branch was updated from `develop/`
    - [x] All conflicts have been resolved
- [x] `CHANGELOG.md` was updated
- [x] Changes do not break
