### PR TITLE
Local Space support for Animators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.0.8-preview] - DATE
 
 ### Added
-- 
+- Added `SPACE.cs` enum, that is used for `PingPongAnimator.cs` & `SimpleSpin.cs` to allow space specific assignments
+- Added `TransformExtensions.cs` to provide Setting `position` & `rotation` functions that use `enum SPACE` as a parameter
 
 ### Changed
-- 
+- Updated `PingPongAnimator.cs` to utilize the `TransformExtension.cs` & `enum SPACE` to provide more flexibility on use
+  - Added `Assert` to `Start()` to help catch potential issues early
+- Updated `SimpleSpin.cs` to utilize the `TransformExtension.cs` & `enum SPACE` to provide more flexibility on use
 
 ### Fixed
 - 

--- a/Documentation~/Utilities/utilities-animators.md
+++ b/Documentation~/Utilities/utilities-animators.md
@@ -1,7 +1,5 @@
 ﻿## Animators
 ### Ping Pong
-> _**NOTE** `Rotation` & `Position` target World Space_
-
 ![example](../Images/pingpong_example.gif)
 
 This animator will Ping-Pong the follow transform values if enabled:
@@ -11,8 +9,7 @@ This animator will Ping-Pong the follow transform values if enabled:
 
 Set the speed _( > 0)_ & the animator curve. This will target the Transform that it's attached to and will run automatically.
 ### Simple Spin
-This animator will rotate the specified degrees per frame * `Time.deltaTime`. It targets the attached Transforms world
-rotation value. Works for both 2D & 3D.
+This animator will rotate the specified degrees per frame * `Time.deltaTime`. Works for both 2D & 3D.
 
 ![example](../Images/simple-spin_example.gif)
 

--- a/Runtime/Scripts/Utilities/Animations/PingPongAnimator.cs
+++ b/Runtime/Scripts/Utilities/Animations/PingPongAnimator.cs
@@ -1,4 +1,8 @@
+using System;
 using UnityEngine;
+using UnityEngine.Assertions;
+using Utilities.Enums;
+using Utilities.Extensions;
 
 namespace Utilities.Animations
 {
@@ -7,7 +11,10 @@ namespace Utilities.Animations
     /// </summary>
     public class PingPongAnimator : MonoBehaviour
     {
-        [SerializeField, Min(0)]
+        [SerializeField]
+        private SPACE space = SPACE.WORLD;
+        
+        [SerializeField, Min(0f)]
         private float speed;
         private float _current;
 
@@ -25,6 +32,12 @@ namespace Utilities.Animations
 
         [SerializeField, Space(10f)]
         private AnimationCurve curve;
+
+        private void Start()
+        {
+            Assert.IsNotNull(curve, $"{nameof(curve)} needs to be set!");
+        }
+
         // Start is called before the first frame update// Update is called once per frame
         private void Update()
         {
@@ -32,13 +45,13 @@ namespace Utilities.Animations
             var t = curve.Evaluate(Mathf.PingPong(_current, 1f));
 
             if(usePosition)
-                transform.position = Vector3.Lerp(startPosition, endPosition, t);
+                transform.SetPosition(space, Vector3.Lerp(startPosition, endPosition, t));
+            
+            if(useRotation)
+                transform.SetRotation(space,Quaternion.Euler(Vector3.Lerp(startRotation, endRotation, t)));
             
             if(useScale)
                 transform.localScale = Vector3.Lerp(startScale, endScale, t);
-            
-            if(useRotation)
-                transform.rotation = Quaternion.Euler(Vector3.Lerp(startRotation, endRotation, t));
         }
     }
 }

--- a/Runtime/Scripts/Utilities/Animations/SimpleSpin.cs
+++ b/Runtime/Scripts/Utilities/Animations/SimpleSpin.cs
@@ -1,9 +1,14 @@
 using UnityEngine;
+using Utilities.Enums;
+using Utilities.Extensions;
 
 namespace Utilities.Animations
 {
     public class SimpleSpin : MonoBehaviour
     {
+        [SerializeField]
+        private SPACE space = SPACE.WORLD;
+        
         public bool reverse;
         [SerializeField]
         private Vector3 spin;
@@ -15,7 +20,7 @@ namespace Utilities.Animations
 
             currentRotation *= Quaternion.Euler(spin * (Time.deltaTime * (reverse ? -1 : 1)));
 
-            transform.rotation = currentRotation;
+            transform.SetRotation(space, currentRotation);
         }
     }
 }

--- a/Runtime/Scripts/Utilities/Enums.meta
+++ b/Runtime/Scripts/Utilities/Enums.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a701c6580c09476384a0c65287c4fa91
+timeCreated: 1761061883

--- a/Runtime/Scripts/Utilities/Enums/SPACE.cs
+++ b/Runtime/Scripts/Utilities/Enums/SPACE.cs
@@ -1,0 +1,8 @@
+﻿namespace Utilities.Enums
+{
+    public enum SPACE
+    {
+        WORLD,
+        LOCAL
+    }
+}

--- a/Runtime/Scripts/Utilities/Enums/SPACE.cs.meta
+++ b/Runtime/Scripts/Utilities/Enums/SPACE.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 11ba09f762d241cb84d85be57618a1f2
+timeCreated: 1761061119

--- a/Runtime/Scripts/Utilities/Extensions/TransformExtensions.cs
+++ b/Runtime/Scripts/Utilities/Extensions/TransformExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Runtime.CompilerServices;
+using UnityEngine;
+using Utilities.Enums;
+
+namespace Utilities.Extensions
+{
+    public static class TransformExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetPosition(this Transform transform, SPACE space, Vector3 targetPosition)
+        {
+            if (space == SPACE.WORLD)
+                transform.position = targetPosition;
+            else
+                transform.localPosition = targetPosition;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetRotation(this Transform transform, SPACE space, Quaternion targetRotation)
+        {
+            if (space == SPACE.WORLD)
+                transform.rotation = targetRotation;
+            else
+                transform.localRotation = targetRotation;
+        }
+    }
+}

--- a/Runtime/Scripts/Utilities/Extensions/TransformExtensions.cs.meta
+++ b/Runtime/Scripts/Utilities/Extensions/TransformExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4d64dcfdb94144bfbb5de66a4ca67d75
+timeCreated: 1761061659


### PR DESCRIPTION
<!--TIP You can follow the formatting tips from Github https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests -->

## Issue
- #56
- #57 

## Description
When implementing either the `PingPongAnimator.cs` or `SimpleSpin.cs`, there was no support for LocalSpace changes, making it not possible to easily move objects nested in a more complex hierarchy.

## Tech Notes
By calling the new Transform extensions, we can now more easily apply transformations by passing either:
- `SPACE.WORLD`
- `SPACE.LOCAL`

### Example Use Case
```cs
//From SimpleSpin.cs
private void Update()
{
    var currentRotation = transform.rotation;
    currentRotation *= Quaternion.Euler(spin * (Time.deltaTime * (reverse ? -1 : 1)));

    //Calling the extension just requires passing what space you want to apply
    transform.SetRotation(space, currentRotation);
}
```

### What's happening behind the scenes
```cs
[MethodImpl(MethodImplOptions.AggressiveInlining)]
public static void SetPosition(this Transform transform, SPACE space, Vector3 targetPosition)
{
    if (space == SPACE.WORLD)
        transform.position = targetPosition;
    else
        transform.localPosition = targetPosition;
}
```

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change

## Checklist
- [x] Branch was updated from `develop/`
    - [x] All conflicts have been resolved
- [x] `CHANGELOG.md` was updated
- [x] All Tests Pass
- [x] Changes do not break