### PR TITLE
fix for document generation

### DIFF
--- a/WebsiteDocs~/package-lock.json
+++ b/WebsiteDocs~/package-lock.json
@@ -150,6 +150,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.17.1.tgz",
       "integrity": "sha512-bd5JBUOP71kPsxwDcvOxqtqXXVo/706NFifZ/O5Rx5GB8ZNVAhg4l7aGoT6jBvEfgmrp2fqPbkdIZ6JnuOpGcw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.17.1",
         "@algolia/requester-browser-xhr": "5.17.1",
@@ -1442,6 +1443,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.17.1.tgz",
       "integrity": "sha512-3CcbT5yTWJDIcBe9ZHgsPi184SkT1kyZi3GWlQU5EFgvq1V73X2sqHRkPCQMe0RA/uvZbB+1sFeAk73eWygeLg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@algolia/client-abtesting": "5.17.1",
         "@algolia/client-analytics": "5.17.1",
@@ -1700,6 +1702,7 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
       "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -2726,6 +2729,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
       "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2826,6 +2830,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
       "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.13",
         "@vue/compiler-sfc": "3.5.13",

--- a/WebsiteDocs~/package.json
+++ b/WebsiteDocs~/package.json
@@ -1,6 +1,9 @@
 {
   "scripts": {
-    "process-docs": "shx rm -rf ./site && shx cp ../WebGLTemplates~/README.md ../Documentation~/WebGL.md && shx cp -r ../Documentation~ ./site && shx cp *.md ./site && shx cp ../README.md ./site/home.md && node .vitepress/prebuild.js",
+    "process-docs": "shx rm -rf ./site && npm run copy-docs && npm run copy-webgl && npm run copy-palette && node .vitepress/prebuild.js",
+    "copy-docs": "shx cp -r ../Documentation~ ./site && shx cp *.md ./site && shx cp ../README.md ./site/home.md",
+    "copy-webgl": "shx cp ../WebGLTemplates~/README.md ./site/WebGL.md",
+    "copy-palette": "shx cp -r ../FixedPaletteTool/Documentation~/* ./site",
     "copy-assets": "shx mkdir -p ./site/public && shx cp -r ./site/Images ./site/public",
     "predocs:dev": "npm run process-docs",
     "docs:dev": "vitepress dev",


### PR DESCRIPTION
## Issue
Vitepress document generation was broken after ``FixedPaletteTool`` was added.  Automated deployments would fail because a dead link was detected to the md file.


## Tech Notes
The prebuild scripts have be amended with a new step to copy the ``FixedPaletteTool`` documentation folder to the site generation folder (as well as the images).

## Type of Change
- [X] Bug Fix
- [ ] New Feature
- [ ] New Sample
- [ ] Breaking Change

## Checklist
- [ ] Branch was updated from `develop/`
    - [ ] All conflicts have been resolved
- [ ] `CHANGELOG.md` was updated
- [ ] All Tests Pass
- [X] Changes do not break
- [X] Builds Successfully
