### PR TITLE
Prevent Gitflow from running on non-script changes

### DIFF
--- a/.github/workflows/game.ci.yml
+++ b/.github/workflows/game.ci.yml
@@ -1,18 +1,25 @@
 # Cheat Sheet: https://github.github.io/actions-cheat-sheet/actions-cheat-sheet.html
 name: Test package
-on: 
+on:
   #push:
-  #  paths-ignore:
-  #  - 'WebsiteDocs~/**'
-  #  - 'WebGLTemplates~/**'
-  #  - 'Documentation~/**'
-  #  - '*.md'
+  #  paths:
+  #  - '**/*.cs'
+  #  - '**/*.asmdef'
+  #  - '**/*.asmref'
+  #  - 'package.json'
+  #  - '.github/workflows/game.ci.yml'
+  #  - '!Samples~/**'
   pull_request:
-    paths-ignore:
-    - 'WebsiteDocs~/**'
-    - 'WebGLTemplates~/**'
-    - 'Documentation~/**'
-    - '*.md'
+    # Only run tests when code that affects them changes.
+    # '**/*.cs' covers Runtime, Editor, Tests, FixedPaletteTool & CastVisualizer.
+    # '!Samples~/**' must stay last so it overrides the positive patterns for samples.
+    paths:
+    - '**/*.cs'
+    - '**/*.asmdef'
+    - '**/*.asmref'
+    - 'package.json'
+    - '.github/workflows/game.ci.yml'
+    - '!Samples~/**'
 
 run-name: >
   Testing Package From ${{ github.event_name == 'pull_request' &&

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `TweenController.HasActiveTween(Transform, TRANSFORM)` for async-side conflict detection in dev builds
 - Removed dead `TweenData.AsAsncTask()` from `TweenController.cs`
 - Extracted `GetCurveT` from `TweenController.cs` into shared `TweenMath.cs` so the sync & async tweens can use the same base
+- Changed test workflow to only run on code changes (`.cs`, `.asmdef`, `.asmref`, `package.json`, the workflow file), so doc & config edits no longer trigger builds
+  - Excluded `Samples~/` so sample changes no longer trigger test builds
 
 ### Fixed
 - Resolved issues with `NaughtyAttributes` attempted references before it was loaded


### PR DESCRIPTION
## Issue
Closes #128

## Description
- Test workflow ran on every PR, including doc- and config-only changes
- Now scoped to run only when files that affect the tests change

## Tech Notes
- Switched the `pull_request` trigger in `.github/workflows/game.ci.yml` from a `paths-ignore` deny-list to a `paths` allow-list
- Runs only on: `**/*.cs`, `**/*.asmdef`, `**/*.asmref`, `package.json`, and the workflow file
- `!Samples~/**` kept last so it overrides the positive patterns and excludes sample changes
- Commented-out `push` trigger updated to mirror the same allow-list

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] New Sample
- [ ] Breaking Change

---

Reviewed by @abr-designs