### PR TITLE
Support for Unity versions `6000.5+`

### DIFF
--- a/.github/workflows/game.ci.yml
+++ b/.github/workflows/game.ci.yml
@@ -91,7 +91,7 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-artifacts
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
-          coverageOptions: 'generateHtmlReport;assemblyFilters:+Jam-starter.*,+FixedPaletteTool.Runtime'
+          #coverageOptions: 'generateHtmlReport;assemblyFilters:+Jam-starter.*,+FixedPaletteTool.Runtime'
           customParameters: -nographics -batchmode
 
       - uses: actions/cache/save@v5
@@ -108,111 +108,111 @@ jobs:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
 
-      - uses: actions/upload-artifact@v4
-        name: Upload Coverage Artifacts
-        if: always()
-        with:
-          name: Coverage results for ${{ matrix.testMode }}
-          path: ${{ steps.tests.outputs.coveragePath }}
+      #- uses: actions/upload-artifact@v4
+      #  name: Upload Coverage Artifacts
+      #  if: always()
+      #  with:
+      #    name: Coverage results for ${{ matrix.testMode }}
+      #    path: ${{ steps.tests.outputs.coveragePath }}
 
-      - name: Generate Coverage Summary
-        run: |
-          python3 << 'EOF'
-          import re
-          import os
+      #- name: Generate Coverage Summary
+      #  run: |
+      #    python3 << 'EOF'
+      #    import re
+      #    import os
 
-          file_path = "${{ steps.tests.outputs.coveragePath }}/Report/index.html"
+      #    file_path = "${{ steps.tests.outputs.coveragePath }}/Report/index.html"
 
-          summary_path = os.environ["GITHUB_STEP_SUMMARY"]
+      #    summary_path = os.environ["GITHUB_STEP_SUMMARY"]
 
-          with open(summary_path, "a") as summary:
+      #    with open(summary_path, "a") as summary:
 
-              if not os.path.exists(file_path):
-                  summary.write("## ❌ Coverage Summary\n\n")
-                  summary.write(f"File not found: `{file_path}`\n")
-                  exit(0)
+      #        if not os.path.exists(file_path):
+      #            summary.write("## ❌ Coverage Summary\n\n")
+      #            summary.write(f"File not found: `{file_path}`\n")
+      #            exit(0)
 
-              with open(file_path, "r", encoding="utf-8") as f:
-                  html = f.read()
+      #        with open(file_path, "r", encoding="utf-8") as f:
+      #            html = f.read()
 
-              # ---------------------------
-              # 📊 SUMMARY TABLE
-              # ---------------------------
-              summary.write("## 📊 Coverage Overview\n\n")
+      #        # ---------------------------
+      #        # 📊 SUMMARY TABLE
+      #        # ---------------------------
+      #        summary.write("## 📊 Coverage Overview\n\n")
 
-              overview_match = re.search(
-                  r'<table class="overview.*?">(.*?)</table>',
-                  html,
-                  re.DOTALL
-              )
+      #        overview_match = re.search(
+      #            r'<table class="overview.*?">(.*?)</table>',
+      #            html,
+      #            re.DOTALL
+      #        )
 
-              if overview_match:
-                  overview_html = overview_match.group(1)
-                  rows = re.findall(r"<tr>(.*?)</tr>", overview_html, re.DOTALL)
+      #        if overview_match:
+      #            overview_html = overview_match.group(1)
+      #            rows = re.findall(r"<tr>(.*?)</tr>", overview_html, re.DOTALL)
 
-                  summary.write("| Metric | Value |\n")
-                  summary.write("|--------|--------|\n")
+      #            summary.write("| Metric | Value |\n")
+      #            summary.write("|--------|--------|\n")
 
-                  for row in rows:
-                      th = re.search(r"<th[^>]*>(.*?)</th>", row)
-                      td = re.search(r"<td[^>]*>(.*?)</td>", row)
+      #            for row in rows:
+      #                th = re.search(r"<th[^>]*>(.*?)</th>", row)
+      #                td = re.search(r"<td[^>]*>(.*?)</td>", row)
 
-                      if not th or not td:
-                          continue
+      #                if not th or not td:
+      #                    continue
 
-                      key = re.sub("<.*?>", "", th.group(1)).strip()
-                      value = re.sub("<.*?>", "", td.group(1)).strip()
+      #                key = re.sub("<.*?>", "", th.group(1)).strip()
+      #                value = re.sub("<.*?>", "", td.group(1)).strip()
 
-                      summary.write(f"| {key} | {value} |\n")
-              else:
-                  summary.write("⚠️ Could not find summary table\n")
+      #                summary.write(f"| {key} | {value} |\n")
+      #        else:
+      #            summary.write("⚠️ Could not find summary table\n")
 
-              # ---------------------------
-              # 📉 DETAILED FILE COVERAGE
-              # ---------------------------
-              summary.write("\n## 📉 File Coverage (Filtered)\n\n")
+      #        # ---------------------------
+      #        # 📉 DETAILED FILE COVERAGE
+      #        # ---------------------------
+      #        summary.write("\n## 📉 File Coverage (Filtered)\n\n")
 
-              rows = re.findall(r"<tr.*?>.*?</tr>", html, re.DOTALL)
+      #        rows = re.findall(r"<tr.*?>.*?</tr>", html, re.DOTALL)
 
-              summary.write("| File | Coverage | Lines |\n")
-              summary.write("|------|----------|--------|\n")
+      #        summary.write("| File | Coverage | Lines |\n")
+      #        summary.write("|------|----------|--------|\n")
 
-              def get_emoji(percent):
-                  if percent >= 80:
-                      return "🟩"
-                  elif percent >= 50:
-                      return "🟨"
-                  else:
-                      return "🟥"
+      #        def get_emoji(percent):
+      #            if percent >= 80:
+      #                return "🟩"
+      #            elif percent >= 50:
+      #                return "🟨"
+      #            else:
+      #                return "🟥"
 
-              entries = []
+      #        entries = []
 
-              for row in rows:
-                  # ONLY rows with <a> (skip <th> assemblies)
-                  name_match = re.search(r"<a[^>]*>(.*?)</a>", row)
-                  if not name_match:
-                      continue
+      #        for row in rows:
+      #            # ONLY rows with <a> (skip <th> assemblies)
+      #            name_match = re.search(r"<a[^>]*>(.*?)</a>", row)
+      #            if not name_match:
+      #                continue
 
-                  name = name_match.group(1)
+      #            name = name_match.group(1)
 
-                  coverage_match = re.search(r'LineCoverage:\s*([0-9]+/[0-9]+)', row)
-                  percent_match = re.search(r'>(\d+(?:\.\d+)?)%</', row)
+      #            coverage_match = re.search(r'LineCoverage:\s*([0-9]+/[0-9]+)', row)
+      #            percent_match = re.search(r'>(\d+(?:\.\d+)?)%</', row)
 
-                  if not coverage_match or not percent_match:
-                      continue
+      #            if not coverage_match or not percent_match:
+      #                continue
 
-                  percent_value = float(percent_match.group(1))
-                  percent_text = f"{percent_value}%"
-                  lines = coverage_match.group(1)
+      #            percent_value = float(percent_match.group(1))
+      #            percent_text = f"{percent_value}%"
+      #            lines = coverage_match.group(1)
 
-                  entries.append((percent_value, name, percent_text, lines))
+      #            entries.append((percent_value, name, percent_text, lines))
 
-              # Sort worst → best (so problems are obvious)
-              for percent_value, name, percent_text, lines in sorted(entries):
-                  emoji = get_emoji(percent_value)
-                  summary.write(f"| {emoji} {name} | {percent_text} | {lines} |\n")
+      #        # Sort worst → best (so problems are obvious)
+      #        for percent_value, name, percent_text, lines in sorted(entries):
+      #            emoji = get_emoji(percent_value)
+      #            summary.write(f"| {emoji} {name} | {percent_text} | {lines} |\n")
 
-              if not entries:
-                  summary.write("\n⚠️ No file-level coverage rows parsed.\n")
+      #        if not entries:
+      #            summary.write("\n⚠️ No file-level coverage rows parsed.\n")
 
-          EOF
+      #    EOF

--- a/.github/workflows/game.ci.yml
+++ b/.github/workflows/game.ci.yml
@@ -49,7 +49,7 @@ jobs:
         testMode: [editmode, playmode] #[editmode, playmode, Standalone]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Download package
         with:
           lfs: true
@@ -101,14 +101,14 @@ jobs:
           path: TempProject/Library
           key: ${{ matrix.testMode }}-${{ matrix.unityVersion }}-Library-TempProject
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         name: Upload Artifacts
         if: always()
         with: 
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         name: Upload Coverage Artifacts
         if: always()
         with:

--- a/.github/workflows/game.ci.yml
+++ b/.github/workflows/game.ci.yml
@@ -76,7 +76,7 @@ jobs:
             ${{ matrix.testMode }}-${{ matrix.unityVersion }}-Library-TempProject-
             ${{ matrix.testMode }}-${{ matrix.unityVersion }}-Library-
 
-      - uses: game-ci/unity-test-runner@v4
+      - uses: abr-designs/unity-test-runner@patch/codecoverage-1.3.0
         name: Run Tests
         id: tests
         env:

--- a/.github/workflows/game.ci.yml
+++ b/.github/workflows/game.ci.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         projectPath: [test-project/Packages/com.abrds.jam-starter]
-        unityVersion: ['6000.4.1f1'] # some version must be included for package testing
+        unityVersion: ${{ fromJson(vars.UNITY_VERSIONS) }} # JSON array set in Settings > Environments > game.ci > Variables
         testMode: [editmode, playmode] #[editmode, playmode, Standalone]
 
     steps:
@@ -71,10 +71,10 @@ jobs:
         id: project-library-restore
         with:
           path: TempProject/Library
-          key: ${{ matrix.testMode }}-Library-TempProject
+          key: ${{ matrix.testMode }}-${{ matrix.unityVersion }}-Library-TempProject
           restore-keys: |
-            ${{ matrix.testMode }}-Library-TempProject-
-            ${{ matrix.testMode }}-Library-
+            ${{ matrix.testMode }}-${{ matrix.unityVersion }}-Library-TempProject-
+            ${{ matrix.testMode }}-${{ matrix.unityVersion }}-Library-
 
       - uses: game-ci/unity-test-runner@v4
         name: Run Tests
@@ -99,7 +99,7 @@ jobs:
         id: project-library-save
         with:
           path: TempProject/Library
-          key: ${{ matrix.testMode }}-Library-TempProject
+          key: ${{ matrix.testMode }}-${{ matrix.unityVersion }}-Library-TempProject
 
       - uses: actions/upload-artifact@v4
         name: Upload Artifacts

--- a/.github/workflows/game.ci.yml
+++ b/.github/workflows/game.ci.yml
@@ -91,7 +91,7 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-artifacts
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
-          #coverageOptions: 'generateHtmlReport;assemblyFilters:+Jam-starter.*,+FixedPaletteTool.Runtime'
+          coverageOptions: 'generateHtmlReport;assemblyFilters:+Jam-starter.*,+FixedPaletteTool.Runtime'
           customParameters: -nographics -batchmode
 
       - uses: actions/cache/save@v5
@@ -108,111 +108,111 @@ jobs:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
 
-      #- uses: actions/upload-artifact@v4
-      #  name: Upload Coverage Artifacts
-      #  if: always()
-      #  with:
-      #    name: Coverage results for ${{ matrix.testMode }}
-      #    path: ${{ steps.tests.outputs.coveragePath }}
+      - uses: actions/upload-artifact@v4
+        name: Upload Coverage Artifacts
+        if: always()
+        with:
+          name: Coverage results for ${{ matrix.testMode }}
+          path: ${{ steps.tests.outputs.coveragePath }}
 
-      #- name: Generate Coverage Summary
-      #  run: |
-      #    python3 << 'EOF'
-      #    import re
-      #    import os
+      - name: Generate Coverage Summary
+        run: |
+          python3 << 'EOF'
+          import re
+          import os
 
-      #    file_path = "${{ steps.tests.outputs.coveragePath }}/Report/index.html"
+          file_path = "${{ steps.tests.outputs.coveragePath }}/Report/index.html"
 
-      #    summary_path = os.environ["GITHUB_STEP_SUMMARY"]
+          summary_path = os.environ["GITHUB_STEP_SUMMARY"]
 
-      #    with open(summary_path, "a") as summary:
+          with open(summary_path, "a") as summary:
 
-      #        if not os.path.exists(file_path):
-      #            summary.write("## ❌ Coverage Summary\n\n")
-      #            summary.write(f"File not found: `{file_path}`\n")
-      #            exit(0)
+              if not os.path.exists(file_path):
+                  summary.write("## ❌ Coverage Summary\n\n")
+                  summary.write(f"File not found: `{file_path}`\n")
+                  exit(0)
 
-      #        with open(file_path, "r", encoding="utf-8") as f:
-      #            html = f.read()
+              with open(file_path, "r", encoding="utf-8") as f:
+                  html = f.read()
 
-      #        # ---------------------------
-      #        # 📊 SUMMARY TABLE
-      #        # ---------------------------
-      #        summary.write("## 📊 Coverage Overview\n\n")
+              # ---------------------------
+              # 📊 SUMMARY TABLE
+              # ---------------------------
+              summary.write("## 📊 Coverage Overview\n\n")
 
-      #        overview_match = re.search(
-      #            r'<table class="overview.*?">(.*?)</table>',
-      #            html,
-      #            re.DOTALL
-      #        )
+              overview_match = re.search(
+                  r'<table class="overview.*?">(.*?)</table>',
+                  html,
+                  re.DOTALL
+              )
 
-      #        if overview_match:
-      #            overview_html = overview_match.group(1)
-      #            rows = re.findall(r"<tr>(.*?)</tr>", overview_html, re.DOTALL)
+              if overview_match:
+                  overview_html = overview_match.group(1)
+                  rows = re.findall(r"<tr>(.*?)</tr>", overview_html, re.DOTALL)
 
-      #            summary.write("| Metric | Value |\n")
-      #            summary.write("|--------|--------|\n")
+                  summary.write("| Metric | Value |\n")
+                  summary.write("|--------|--------|\n")
 
-      #            for row in rows:
-      #                th = re.search(r"<th[^>]*>(.*?)</th>", row)
-      #                td = re.search(r"<td[^>]*>(.*?)</td>", row)
+                  for row in rows:
+                      th = re.search(r"<th[^>]*>(.*?)</th>", row)
+                      td = re.search(r"<td[^>]*>(.*?)</td>", row)
 
-      #                if not th or not td:
-      #                    continue
+                      if not th or not td:
+                          continue
 
-      #                key = re.sub("<.*?>", "", th.group(1)).strip()
-      #                value = re.sub("<.*?>", "", td.group(1)).strip()
+                      key = re.sub("<.*?>", "", th.group(1)).strip()
+                      value = re.sub("<.*?>", "", td.group(1)).strip()
 
-      #                summary.write(f"| {key} | {value} |\n")
-      #        else:
-      #            summary.write("⚠️ Could not find summary table\n")
+                      summary.write(f"| {key} | {value} |\n")
+              else:
+                  summary.write("⚠️ Could not find summary table\n")
 
-      #        # ---------------------------
-      #        # 📉 DETAILED FILE COVERAGE
-      #        # ---------------------------
-      #        summary.write("\n## 📉 File Coverage (Filtered)\n\n")
+              # ---------------------------
+              # 📉 DETAILED FILE COVERAGE
+              # ---------------------------
+              summary.write("\n## 📉 File Coverage (Filtered)\n\n")
 
-      #        rows = re.findall(r"<tr.*?>.*?</tr>", html, re.DOTALL)
+              rows = re.findall(r"<tr.*?>.*?</tr>", html, re.DOTALL)
 
-      #        summary.write("| File | Coverage | Lines |\n")
-      #        summary.write("|------|----------|--------|\n")
+              summary.write("| File | Coverage | Lines |\n")
+              summary.write("|------|----------|--------|\n")
 
-      #        def get_emoji(percent):
-      #            if percent >= 80:
-      #                return "🟩"
-      #            elif percent >= 50:
-      #                return "🟨"
-      #            else:
-      #                return "🟥"
+              def get_emoji(percent):
+                  if percent >= 80:
+                      return "🟩"
+                  elif percent >= 50:
+                      return "🟨"
+                  else:
+                      return "🟥"
 
-      #        entries = []
+              entries = []
 
-      #        for row in rows:
-      #            # ONLY rows with <a> (skip <th> assemblies)
-      #            name_match = re.search(r"<a[^>]*>(.*?)</a>", row)
-      #            if not name_match:
-      #                continue
+              for row in rows:
+                  # ONLY rows with <a> (skip <th> assemblies)
+                  name_match = re.search(r"<a[^>]*>(.*?)</a>", row)
+                  if not name_match:
+                      continue
 
-      #            name = name_match.group(1)
+                  name = name_match.group(1)
 
-      #            coverage_match = re.search(r'LineCoverage:\s*([0-9]+/[0-9]+)', row)
-      #            percent_match = re.search(r'>(\d+(?:\.\d+)?)%</', row)
+                  coverage_match = re.search(r'LineCoverage:\s*([0-9]+/[0-9]+)', row)
+                  percent_match = re.search(r'>(\d+(?:\.\d+)?)%</', row)
 
-      #            if not coverage_match or not percent_match:
-      #                continue
+                  if not coverage_match or not percent_match:
+                      continue
 
-      #            percent_value = float(percent_match.group(1))
-      #            percent_text = f"{percent_value}%"
-      #            lines = coverage_match.group(1)
+                  percent_value = float(percent_match.group(1))
+                  percent_text = f"{percent_value}%"
+                  lines = coverage_match.group(1)
 
-      #            entries.append((percent_value, name, percent_text, lines))
+                  entries.append((percent_value, name, percent_text, lines))
 
-      #        # Sort worst → best (so problems are obvious)
-      #        for percent_value, name, percent_text, lines in sorted(entries):
-      #            emoji = get_emoji(percent_value)
-      #            summary.write(f"| {emoji} {name} | {percent_text} | {lines} |\n")
+              # Sort worst → best (so problems are obvious)
+              for percent_value, name, percent_text, lines in sorted(entries):
+                  emoji = get_emoji(percent_value)
+                  summary.write(f"| {emoji} {name} | {percent_text} | {lines} |\n")
 
-      #        if not entries:
-      #            summary.write("\n⚠️ No file-level coverage rows parsed.\n")
+              if not entries:
+                  summary.write("\n⚠️ No file-level coverage rows parsed.\n")
 
-      #    EOF
+          EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Resolved Dead links in documentation
+- Resolved `game.ci.yml` failing on Unity 6000.5+ by pinning `unity-test-runner` to `abr-designs/unity-test-runner@patch/codecoverage-1.3.0`, which bumps the injected `com.unity.testtools.codecoverage` from `1.1.1` to `1.3.0`
 
 ### Changed
 - Moved CI Unity versions from hardcoded matrix into environment variable `UNITY_VERSIONS` in `game.ci.yml`, parsed as a JSON array by `fromJson()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - 
 
 ### Fixed
-- 
+- Resolved Dead links in documentation
 
 ### Changed
 - 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.0.11 - preview] - DATE
 
 ### Added
-- 
+- Unity 6000.5+ support
+  - Updated package.json dependencies & minimum version
+  - Updated README to reflect the changes
 
 ### Fixed
 - Resolved Dead links in documentation
 
 ### Changed
-- 
+- Moved CI Unity versions from hardcoded matrix into environment variable `UNITY_VERSIONS` in `game.ci.yml`, parsed as a JSON array by `fromJson()`
+  - Added `unityVersion` to the Library cache key to prevent collision across versions
 
 ## [0.0.10] - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Moved CI Unity versions from hardcoded matrix into environment variable `UNITY_VERSIONS` in `game.ci.yml`, parsed as a JSON array by `fromJson()`
   - Added `unityVersion` to the Library cache key to prevent collision across versions
+- Bumped `actions/checkout` & `actions/upload-artifact` from `v4` to `v5` in `game.ci.yml` to clear the Node 20 deprecation warning
 
 ## [0.0.10] - 2026-07-05
 

--- a/Documentation~/Utilities/utilities-text-animation.md
+++ b/Documentation~/Utilities/utilities-text-animation.md
@@ -196,7 +196,7 @@ What "Not visible" entails:
 > Types are marked `[Preserve]` so IL2CPP stripping keeps effect classes that nothing references directly.
 
 Effects are discovered by reflection at boot time using `[RuntimeInitializeOnLoadMethod(BeforeSceneLoad)]`. The [`TextEffectRegistry`](../../Runtime/Scripts/Utilities/TextAnimation/TextEffectRegistry.cs) scans every loaded
-assembly for non-abstract [`MotionTextEffect`](../../Runtime/Scripts/Utilities/TextAnimation/MotionTextEffect.cs) & [`ColorTextEffect`](../../Runtime/Scripts/Utilities/TextAnimation/ColorTextEffect.cs) subclasses carrying a [`[TextEffect("key")]`](../../Runtime/Scripts/Utilities/TextAnimation/TextEffectAttribute.cs) attribute, instantiates
+assembly for non-abstract [`MotionTextEffect`](../../Runtime/Scripts/Utilities/TextAnimation/MotionTextEffect.cs) & [`ColorTextEffect`](../../Runtime/Scripts/Utilities/TextAnimation/ColorTextEffect.cs) subclasses carrying a [`[TextEffect("key")]`](../../Runtime/Scripts/Utilities/TextAnimation/Helpers/TextEffectAttribute.cs) attribute, instantiates
 one shared instance per key. Keys resolve per channel, so a motion key & a color key may reuse the same string. Key lookups are case-insensitive, so `motion="Wave"` resolves the same effect as `motion="wave"`.
 
 ## Adding a new effect

--- a/Editor/Packages/AddPackages.cs
+++ b/Editor/Packages/AddPackages.cs
@@ -18,7 +18,7 @@ namespace JamStarter.Editor
             ("com.dbrizov.naughtyattributes", "https://github.com/dbrizov/NaughtyAttributes.git#upm"),
             ("com.gitamend.unityutils", "https://github.com/adammyhre/Unity-Utils.git"),
             ("ayellowpaper.serialized-dictionary", "https://github.com/ayellowpaper/SerializedDictionary.git"),
-            ("com.cysharp.unitask", "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask"),
+            ("com.cysharp.unitask", "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#2.5.11"),
             ("com.github-glitchenzo.nugetforunity", "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity")
         };
     

--- a/Editor/Packages/AddPackages.cs
+++ b/Editor/Packages/AddPackages.cs
@@ -15,7 +15,7 @@ namespace JamStarter.Editor
 
         private static readonly (string packageId, string packageUrl)[] Packages =
         {
-            ("com.dbrizov.naughtyattributes", "https://github.com/dbrizov/NaughtyAttributes.git#upm"),
+            ("com.dbrizov.naughtyattributes", "https://github.com/dbrizov/NaughtyAttributes.git#c37fb61a687a49fb61b0b48c47599cc8ddd9443e"),
             ("com.gitamend.unityutils", "https://github.com/adammyhre/Unity-Utils.git"),
             ("ayellowpaper.serialized-dictionary", "https://github.com/ayellowpaper/SerializedDictionary.git"),
             ("com.cysharp.unitask", "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#2.5.11"),

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ projects & Game jams.
   - #### [Wait-For Animations](Documentation~/Utilities/utilities-wait-animation.md)
   - #### [Physics](Documentation~/Utilities/utilities-physics.md)
   - #### [Extensions](Documentation~/Utilities/utilities-extensions.md)
-  - #### [Transform Tweens](Documentation~/Utilities/utilities-extensions-transform.md)
+  - #### [Transform Tweens](Documentation~/Utilities/utilities-transform-tweening.md)
   - #### [Debugging - Draw.cs](Documentation~/Utilities/utilities-draw.md)
   - #### [Recycling](Documentation~/Utilities/utilities-recycling.md)
   - #### [Singletons](Documentation~/Utilities/utilities-singletons.md)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ projects & Game jams.
 > - Paste `https://github.com/abr-designs/jam-starter-package.git#unity/version-support/pre-6000` into the text box
 
 ### `v0.0.11-preview` - DATE
-### Supports Unity 6000.0
+### Supports Unity 6000.5+
 
 ## Samples
 > To add samples, navigate to the **_Package Manager window → Jam Starter Kit → Samples_**
@@ -59,10 +59,9 @@ projects & Game jams.
 | Package          | Version |
 |------------------|---------|
 | [Unity Feature 2d](https://docs.unity3d.com/6000.0/Documentation/Manual/2DFeature.html) | Default |
-| [TextMeshPro](https://docs.unity3d.com/Packages/com.unity.ugui@2.0/manual/TextMeshPro/index.html)   | 3.0.9   |
-| [Cinemachine](https://docs.unity3d.com/Packages/com.unity.cinemachine@2.3/manual/CinemachineOverview.html)    | 2.10.1  |
-| [New Input System](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.11/manual/index.html) | 1.7.0   |
-| [Newtonsoft JSON](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/manual/index.html) | 3.2.1   |
+| [Cinemachine](https://docs.unity3d.com/Packages/com.unity.cinemachine@2.3/manual/CinemachineOverview.html)    | 3.1.7   |
+| [New Input System](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.11/manual/index.html) | 1.19.0  |
+| [Newtonsoft JSON](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/manual/index.html) | 3.2.2   |
 
 #### Custom Packages
 > _See [`AddPackages.cs`](Editor/Packages/AddPackages.cs)_

--- a/Runtime/Jam-starter.Runtime.asmdef
+++ b/Runtime/Jam-starter.Runtime.asmdef
@@ -14,7 +14,7 @@
     "versionDefines": [
         {
             "name": "com.dbrizov.naughtyattributes",
-            "expression": "2.1.4",
+            "expression": "2.1.6",
             "define": "NAUGHTY"
         }
     ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.abrds.jam-starter",
   "displayName": "Jam Starter Kit",
   "version": "0.0.11-preview",
-  "unity": "6000.0",
+  "unity": "6000.5",
   "description": "A collection of scripts & samples to help kick start Game Jam projects. Includes some custom packages",
   "keywords": [
     "jam"
@@ -17,11 +17,11 @@
   },
   "documentationUrl": "https://abr-designs.github.io/jam-starter-package/",
   "dependencies": {
-    "com.unity.ugui": "2.0.0",
-    "com.unity.feature.2d": "2.0.1",
-    "com.unity.nuget.newtonsoft-json": "3.2.1",
-    "com.unity.cinemachine": "3.1.2",
-    "com.unity.inputsystem": "1.11.2"
+    "com.unity.ugui": "2.5.0",
+    "com.unity.feature.2d": "2.0.2",
+    "com.unity.nuget.newtonsoft-json": "3.2.2",
+    "com.unity.cinemachine": "3.1.7",
+    "com.unity.inputsystem": "1.19.0"
   },
   "samples": [
     {


### PR DESCRIPTION
<!--TIP You can follow the formatting tips from Github https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests -->

## Issue
- Closes #130

## Description
Bumps the package's minimum Unity version to `6000.5` & upgrades all dependencies to the versions shipped with that editor.

- Updated version header to `v0.0.11-preview` & supported editor to `6000.5+`
- Refreshed the dependency version table to match `package.json`
- Removed the standalone `TextMeshPro` row (rolled into `com.unity.ugui` in `6000.5`)
- Fixed the Transform Tweens documentation link (`utilities-extensions-transform.md` → `utilities-transform-tweening.md`)

### Dependencies
| Package | Before | After |
|---|---|---|
| `com.unity.ugui` | `2.0.0` | `2.5.0` |
| `com.unity.feature.2d` | `2.0.1` | `2.0.2` |
| `com.unity.nuget.newtonsoft-json` | `3.2.1` | `3.2.2` |
| `com.unity.cinemachine` | `3.1.2` | `3.1.7` |
| `com.unity.inputsystem` | `1.11.2` | `1.19.0` |

## Tech Notes

> [!IMPORTANT]
> This raises the minimum supported editor to `6000.5`. Projects on earlier `6000.x` editors will fail to resolve the package.

### `game.ci.yml`
- Replaced the hardcoded `unityVersion` matrix entry with `${{ fromJson(vars.UNITY_VERSIONS) }}`, sourced from the `game.ci` environment variable so the CI matrix can be edited without touching the workflow file
- Added `${{ matrix.unityVersion }}` to the Library cache `key` & `restore-keys` so caches from different editor versions do not collide


## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] New Sample
- [ ] Breaking Change
- [x] Upgrade

## Checklist
- [x] Branch was updated from `develop/`
    - [x] All conflicts have been resolved
- [x] `CHANGELOG.md` was updated
- [x] All Tests Pass
- [x] Changes do not break
- [x] Builds Successfully
