### PR TITLE
Centralized audio volume control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Unity 6000.5+ support
   - Updated package.json dependencies & minimum version
   - Updated README to reflect the changes
+- Added `VolumeController` to the Sounds sample as the single entry point for volume, exposing `SetMasterVolume()`, `SetMusicVolume()` & `SetSFXVolume()`
+  - Added the component to the `=== Audio Controllers ===` prefab, referencing the master mixer group & both child controllers
+  - Added `AudioMixerExtensions.SetVolume()`, holding the logarithmic slider conversion so each controller sets volume in one call
 
 ### Fixed
 - Resolved Dead links in documentation
+- Resolved the Main Menu sample volume sliders logging an error instead of setting volume, routing them through `VolumeController`
+- Resolved the `--- MUSIC CONTROLLER ---` prefab shipping an unassigned mixer reference
 - Resolved `game.ci.yml` failing on Unity 6000.5+ by pinning `unity-test-runner` to `abr-designs/unity-test-runner@patch/codecoverage-1.3.0`, which bumps the injected `com.unity.testtools.codecoverage` from `1.1.1` to `1.3.0`
 
 ### Changed
 - Moved CI Unity versions from hardcoded matrix into environment variable `UNITY_VERSIONS` in `game.ci.yml`, parsed as a JSON array by `fromJson()`
   - Added `unityVersion` to the Library cache key to prevent collision across versions
 - Bumped `actions/checkout` & `actions/upload-artifact` from `v4` to `v5` in `game.ci.yml` to clear the Node 20 deprecation warning
+- Moved `ISetVolume` from the `Sounds` namespace to `Audio`, matching the controllers that implement it
+- `MusicController` & `SFXManager` delegate their volume conversion to `AudioMixer.SetVolume()`
+  - `MusicController` serializes an `AudioMixerGroup` instead of an `AudioMixer`, matching `SFXManager`
+  - Removed the unused `SFXManager.instance` accessor
 
 ## [0.0.10] - 2026-07-05
 

--- a/Samples~/MainMenu/SettingsUI.cs
+++ b/Samples~/MainMenu/SettingsUI.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Audio;
+using Audio.Music;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -43,15 +45,15 @@ namespace UI
 
         private void OnMasterVolumeChanged(float value)
         {
-            Debug.LogError("MUST CONNECT MASTER VOLUME.\nChange no Saved...");
+            VolumeController.SetMasterVolume(value);
         }
         private void OnMusicVolumeChanged(float value)
         {
-            Debug.LogError("MUST MUSIC MASTER VOLUME.\nChange no Saved...");
+            VolumeController.SetMusicVolume(value);
         }
         private void OnSFXVolumeChanged(float value)
         {
-            Debug.LogError("MUST SFX MASTER VOLUME.\nChange no Saved...");
+            VolumeController.SetSFXVolume(value);
         }
 
         //Volume Settings Class

--- a/Samples~/Sounds/=== Audio Controllers ===.prefab
+++ b/Samples~/Sounds/=== Audio Controllers ===.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5491651014156849475}
+  - component: {fileID: 1539738689791926609}
   m_Layer: 0
   m_Name: === Audio Controllers ===
   m_TagString: Untagged
@@ -33,6 +34,21 @@ Transform:
   - {fileID: 298367242610264409}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1539738689791926609
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3619196265895802025}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd5ae110bcd54650af64d67812ae293f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Audio.VolumeController
+  sfxAudioMixer: {fileID: 24300002, guid: ce08768a569db8b429bc3e45071f1f19, type: 2}
+  sfxVolume: {fileID: 8474390320086256997}
+  musicVolume: {fileID: 3889470561879482652}
 --- !u!1001 &2195155630214551194
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -107,6 +123,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4639160114996083827, guid: d880fbacf2e96044abf72ff550afb8f3, type: 3}
   m_PrefabInstance: {fileID: 2195155630214551194}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8474390320086256997 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7777109018335714303, guid: d880fbacf2e96044abf72ff550afb8f3, type: 3}
+  m_PrefabInstance: {fileID: 2195155630214551194}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 04c81e6ee4391f244b58945a330c97b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &8325723625426484997
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -201,3 +228,14 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8624088634518845020, guid: 64e020dcbf081c04aaa5df70cab3190b, type: 3}
   m_PrefabInstance: {fileID: 8325723625426484997}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &3889470561879482652 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5075773765866298905, guid: 64e020dcbf081c04aaa5df70cab3190b, type: 3}
+  m_PrefabInstance: {fileID: 8325723625426484997}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 319754b37f7adbf4d931e3f86c7bd972, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Samples~/Sounds/=== Audio Controllers ===.prefab
+++ b/Samples~/Sounds/=== Audio Controllers ===.prefab
@@ -46,7 +46,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bd5ae110bcd54650af64d67812ae293f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Audio.VolumeController
-  sfxAudioMixer: {fileID: 24300002, guid: ce08768a569db8b429bc3e45071f1f19, type: 2}
+  masterAudioMixer: {fileID: 24300002, guid: ce08768a569db8b429bc3e45071f1f19, type: 2}
   sfxVolume: {fileID: 8474390320086256997}
   musicVolume: {fileID: 3889470561879482652}
 --- !u!1001 &2195155630214551194

--- a/Samples~/Sounds/Extensions.meta
+++ b/Samples~/Sounds/Extensions.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 932ec0e2c4314bd4bdd4a94ad5af7f87
+timeCreated: 1786289280

--- a/Samples~/Sounds/Extensions/AudioMixerExtensions.cs
+++ b/Samples~/Sounds/Extensions/AudioMixerExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace Audio
+{
+    public static class AudioMixerExtensions
+    {
+        public static void SetVolume(this UnityEngine.Audio.AudioMixer instance, float volume)
+        {
+            var v = UnityEngine.Mathf.Log10(volume) * 20;
+            instance.SetFloat(ISetVolume.VOLUME_ID, v);
+        }
+    }
+}

--- a/Samples~/Sounds/Extensions/AudioMixerExtensions.cs.meta
+++ b/Samples~/Sounds/Extensions/AudioMixerExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0ea59fa0568f4fac9be5b1d6884b8e45
+timeCreated: 1786289291

--- a/Samples~/Sounds/Interfaces/ISetVolume.cs
+++ b/Samples~/Sounds/Interfaces/ISetVolume.cs
@@ -1,4 +1,5 @@
-﻿namespace Sounds
+﻿
+namespace Audio
 {
     public interface ISetVolume
     {
@@ -6,4 +7,6 @@
         
         void SetVolume(float volume);
     }
+    
+
 }

--- a/Samples~/Sounds/Music/Prefabs/--- MUSIC CONTROLLER ---.prefab
+++ b/Samples~/Sounds/Music/Prefabs/--- MUSIC CONTROLLER ---.prefab
@@ -44,7 +44,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 319754b37f7adbf4d931e3f86c7bd972, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  musicAudioMixer: {fileID: 0}
+  musicAudioMixer: {fileID: -4409203865058805600, guid: ce08768a569db8b429bc3e45071f1f19, type: 2}
   startMusic: 1
   crossFadeTime: 2
   musicDatas:

--- a/Samples~/Sounds/Music/Scripts/MusicController.cs
+++ b/Samples~/Sounds/Music/Scripts/MusicController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Sounds;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.Audio;
@@ -27,8 +26,7 @@ namespace Audio.Music
         //------------------------------------------------//
 
         [SerializeField]
-        private AudioMixer musicAudioMixer;
-
+        private AudioMixerGroup musicAudioMixer;
         [SerializeField]
         private MUSIC startMusic;
 
@@ -164,11 +162,7 @@ namespace Audio.Music
         //============================================================================================================//
         
         //Based on: https://johnleonardfrench.com/the-right-way-to-make-a-volume-slider-in-unity-using-logarithmic-conversion/
-        public void SetVolume(float volume)
-        {
-            var v = Mathf.Log10(volume) * 20;
-            Instance.musicAudioMixer.SetFloat(ISetVolume.VOLUME_ID, v);
-        }
+        public void SetVolume(float volume) => Instance.musicAudioMixer.audioMixer.SetVolume(volume);
         
         //Unity Editor Functions
         //============================================================================================================//

--- a/Samples~/Sounds/SoundFx/Prefabs/--- SFX CONTROLLER ---.prefab
+++ b/Samples~/Sounds/SoundFx/Prefabs/--- SFX CONTROLLER ---.prefab
@@ -43,6 +43,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: -5126370574719963628, guid: ce08768a569db8b429bc3e45071f1f19, type: 2}
   m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
   m_PlayOnAwake: 1
   m_Volume: 1
   m_Pitch: 1

--- a/Samples~/Sounds/SoundFx/Scripts/SFXManager.cs
+++ b/Samples~/Sounds/SoundFx/Scripts/SFXManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Sounds;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.Audio;
@@ -13,8 +12,6 @@ namespace Audio
 {
     public class SFXManager : HiddenSingleton<SFXManager>, ISetVolume
     {
-        internal static SFXManager instance => Instance;
-        
         //============================================================================================================//
         [Serializable]
         private class SfxData
@@ -235,13 +232,7 @@ namespace Audio
 
         //Set Volume
         //============================================================================================================//
-        
-        //Based on: https://johnleonardfrench.com/the-right-way-to-make-a-volume-slider-in-unity-using-logarithmic-conversion/
-        public void SetVolume(float volume)
-        {
-            var v = Mathf.Log10(volume) * 20;
-            Instance.sfxAudioMixer.audioMixer.SetFloat(ISetVolume.VOLUME_ID, v);
-        }
+        public void SetVolume(float volume) => Instance.sfxAudioMixer.audioMixer.SetVolume(volume);
 
         //Unity Editor Functions
         //============================================================================================================//

--- a/Samples~/Sounds/VolumeController.cs
+++ b/Samples~/Sounds/VolumeController.cs
@@ -8,10 +8,10 @@ namespace Audio
     public class VolumeController : HiddenSingleton<VolumeController>, ISetVolume
     {
         [SerializeField]
-        private AudioMixerGroup sfxAudioMixer;
-        [SerializeReference]
+        private AudioMixerGroup masterAudioMixer;
+        [SerializeField]
         private SFXManager sfxVolume;
-        [SerializeReference]
+        [SerializeField]
         private MusicController musicVolume;
 
         public static void SetMasterVolume(float volume) => Instance?.SetVolume(volume);
@@ -19,6 +19,6 @@ namespace Audio
         public static void SetSFXVolume(float volume) => Instance?.sfxVolume?.SetVolume(volume);
         
         //Based on: https://johnleonardfrench.com/the-right-way-to-make-a-volume-slider-in-unity-using-logarithmic-conversion/
-        public void SetVolume(float volume) => sfxAudioMixer.audioMixer.SetVolume(volume);
+        public void SetVolume(float volume) => masterAudioMixer.audioMixer.SetVolume(volume);
     }
 }

--- a/Samples~/Sounds/VolumeController.cs
+++ b/Samples~/Sounds/VolumeController.cs
@@ -1,0 +1,24 @@
+﻿using Audio.Music;
+using UnityEngine;
+using UnityEngine.Audio;
+using Utilities;
+
+namespace Audio
+{
+    public class VolumeController : HiddenSingleton<VolumeController>, ISetVolume
+    {
+        [SerializeField]
+        private AudioMixerGroup sfxAudioMixer;
+        [SerializeReference]
+        private SFXManager sfxVolume;
+        [SerializeReference]
+        private MusicController musicVolume;
+
+        public static void SetMasterVolume(float volume) => Instance?.SetVolume(volume);
+        public static void SetMusicVolume(float volume) => Instance?.musicVolume?.SetVolume(volume);
+        public static void SetSFXVolume(float volume) => Instance?.sfxVolume?.SetVolume(volume);
+        
+        //Based on: https://johnleonardfrench.com/the-right-way-to-make-a-volume-slider-in-unity-using-logarithmic-conversion/
+        public void SetVolume(float volume) => sfxAudioMixer.audioMixer.SetVolume(volume);
+    }
+}

--- a/Samples~/Sounds/VolumeController.cs.meta
+++ b/Samples~/Sounds/VolumeController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bd5ae110bcd54650af64d67812ae293f
+timeCreated: 1786288535


### PR DESCRIPTION
## Issue
- No open issue

## Description
- Adds a single place to set audio volume in the Sounds sample, instead of reaching for each controller separately
- `VolumeController.SetMasterVolume()`, `SetMusicVolume()` & `SetSFXVolume()` are static, so any UI can call them without a reference
- Main Menu volume sliders are connected & working, replacing the placeholder error logs
- The logarithmic slider-to-decibel conversion lives in one place, so each controller no longer repeats it

## Tech Notes

> [!IMPORTANT]
> `ISetVolume` moved from the `Sounds` namespace to `Audio`. Any project code with `using Sounds;` for it needs updating.

### `VolumeController.cs`
- New `HiddenSingleton<VolumeController>` implementing `ISetVolume`, added to the `=== Audio Controllers ===` prefab
- Serializes `masterAudioMixer` plus references to the child `SFXManager` & `MusicController`, wired on the prefab
- Static setters null-check `Instance` & the child controllers, so calls before the prefab loads are a no-op

### `AudioMixerExtensions.cs`
- New `AudioMixer.SetVolume(float)` extension holding the `Mathf.Log10(volume) * 20` conversion & the `SetFloat` call

> [!TIP]
> Conversion is unchanged, based on [the right way to make a volume slider](https://johnleonardfrench.com/the-right-way-to-make-a-volume-slider-in-unity-using-logarithmic-conversion/)

### `MusicController.cs`
- `SetVolume()` reduced to one call through the extension
- `musicAudioMixer` changed from `AudioMixer` to `AudioMixerGroup`, matching `SFXManager`
- Assigned the mixer group on the `--- MUSIC CONTROLLER ---` prefab, which was previously empty

### `SFXManager.cs`
- `SetVolume()` reduced to one call through the extension
- Removed the unused `instance` accessor

### `SettingsUI.cs`
- The three slider callbacks call `VolumeController` instead of logging an error

### Misc
- `--- SFX CONTROLLER ---` prefab picked up Unity's new `m_Resource` `AudioSource` field on serialization

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] New Sample
- [x] Sample Improvement
- [ ] Breaking Change

## Checklist
- [x] Branch was updated from `develop/`
    - [x] All conflicts have been resolved
- [x] `CHANGELOG.md` was updated
- [x] All Tests Pass
- [x] Changes do not break
- [x] Builds Successfully
